### PR TITLE
First pass at parameterizing script inputs used in tp53_analysis.sh

### DIFF
--- a/scripts/apply_weights.py
+++ b/scripts/apply_weights.py
@@ -34,17 +34,17 @@ parser.add_argument('-u', '--copy_number', action='store_true',
 
 parser.add_argument('-x', '--x_matrix', default=None,
                     help='Filename of features to use in model')
-parser.add_argument( '--filename_mut', default=None,
+parser.add_argument('--filename_mut', default=None,
                     help='Filename of sample/gene mutations to use in model')
-parser.add_argument( '--filename_mut_burden', default=None,
+parser.add_argument('--filename_mut_burden', default=None,
                     help='Filename of sample mutation burden to use in model')
-parser.add_argument( '--filename_sample', default=None,
+parser.add_argument('--filename_sample', default=None,
                     help='Filename of patient/samples to use in model')
-parser.add_argument( '--filename_copy_loss', default=None,
+parser.add_argument('--filename_copy_loss', default=None,
                     help='Filename of copy number loss')
-parser.add_argument( '--filename_copy_gain', default=None,
+parser.add_argument('--filename_copy_gain', default=None,
                     help='Filename of copy number gain')
-parser.add_argument( '--filename_cancer_gene_classification', default=None,
+parser.add_argument('--filename_cancer_gene_classification', default=None,
                     help='Filename of cancer gene classification table')
 
 args = parser.parse_args()

--- a/scripts/apply_weights.py
+++ b/scripts/apply_weights.py
@@ -31,6 +31,22 @@ parser.add_argument('-c', '--classifier',
                     help='folder location of classifier file')
 parser.add_argument('-u', '--copy_number', action='store_true',
                     help='Supplement Y matrix with copy number events')
+
+parser.add_argument('-x', '--x_matrix', default=None,
+                    help='Filename of features to use in model')
+parser.add_argument( '--filename_mut', default=None,
+                    help='Filename of sample/gene mutations to use in model')
+parser.add_argument( '--filename_mut_burden', default=None,
+                    help='Filename of sample mutation burden to use in model')
+parser.add_argument( '--filename_sample', default=None,
+                    help='Filename of patient/samples to use in model')
+parser.add_argument( '--filename_copy_loss', default=None,
+                    help='Filename of copy number loss')
+parser.add_argument( '--filename_copy_gain', default=None,
+                    help='Filename of copy number gain')
+parser.add_argument( '--filename_cancer_gene_classification', default=None,
+                    help='Filename of cancer gene classification table')
+
 args = parser.parse_args()
 
 # Load command arguments
@@ -38,13 +54,13 @@ classifier_file = os.path.join(args.classifier, 'classifier_summary.txt')
 copy_number = args.copy_number
 
 # Load Constants
-rnaseq_file = os.path.join('data', 'pancan_rnaseq_freeze.tsv')
-mut_file = os.path.join('data', 'pancan_mutation_freeze.tsv')
-sample_freeze_file = os.path.join('data', 'sample_freeze.tsv')
-cancer_gene_file = os.path.join('data', 'vogelstein_cancergenes.tsv')
-copy_loss_file = os.path.join('data', 'copy_number_loss_status.tsv')
-copy_gain_file = os.path.join('data', 'copy_number_gain_status.tsv')
-mutation_burden_file = os.path.join('data', 'mutation_burden_freeze.tsv')
+rnaseq_file = args.x_matrix or os.path.join('data', 'pancan_rnaseq_freeze.tsv')
+mut_file = args.filename_mut or os.path.join('data', 'pancan_mutation_freeze.tsv')
+sample_freeze_file = args.filename_sample or os.path.join('data', 'sample_freeze.tsv')
+cancer_gene_file = args.filename_cancer_gene_classification or os.path.join('data', 'vogelstein_cancergenes.tsv')
+copy_loss_file = args.filename_copy_loss or os.path.join('data', 'copy_number_loss_status.tsv')
+copy_gain_file = args.filename_copy_gain or os.path.join('data', 'copy_number_gain_status.tsv')
+mutation_burden_file = args.filename_mut_burden or os.path.join('data', 'mutation_burden_freeze.tsv')
 
 # Generate filenames to save output plots
 output_base_file = os.path.dirname(classifier_file)
@@ -65,7 +81,11 @@ with open(classifier_file) as class_fh:
         if line[0] == 'Diseases:':
             diseases = line[1:]
         if line[0] == 'Coefficients:':
-            coef_df = pd.read_table(line[1])
+            coef_df = line[1]
+            # If file DNE (e.g. jobs executed with file staging), fallback to local copy
+            if not os.path.exists(coef_df):
+                coef_df = os.path.join(args.classifier, 'classifier_coefficients.tsv')
+            coef_df = pd.read_table(coef_df)
 
 # Subset matrix that indicates mutation status (y)
 common_genes = set(mutation_df.columns).intersection(genes)

--- a/scripts/copy_burden_figures.R
+++ b/scripts/copy_burden_figures.R
@@ -39,14 +39,13 @@ option_list = list(
   )
 )
 
-opt <-parse_args(OptionParser(option_list = option_list))
+opt <- parse_args(OptionParser(option_list = option_list))
 
 if (opt$version){
   # print version and exit
   cat(paste("PanCancer version", toString(packageVersion("pancancer"))), "\n")
   quit()
 }
-
 
 # Set File Names
 if ( !is.na(opt$alt_folder) ){
@@ -61,7 +60,6 @@ if ( !is.na(opt$alt_folder) ){
   snaptron_file <- file.path("scripts", "snaptron",
                              "junctions_with_mutations.csv.gz")
 }
-
 
 frac_alt_plot <- file.path(base_file, "figures", "fraction_altered_plot.pdf")
 violin_plot <- file.path(base_file, "figures", "seg_altered_violin_plot.pdf")

--- a/scripts/copy_burden_figures.R
+++ b/scripts/copy_burden_figures.R
@@ -12,13 +12,57 @@
 # Output:
 # Two figures summarizing copy burden across TCGA Pan Can samples
 
+library(optparse)
 library(ggplot2)
 
+# parse options
+option_list = list(
+   make_option(
+    c("--version"),
+    action = "store_true",
+    default = FALSE,
+    help = "Print version and exit"
+   ),
+  make_option(
+    c("--alt_folder"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = "Classifier base folder"
+  ),
+  make_option(
+    c("--junctions_with_mutations"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = "junctions_with_mutations.csv.gz"
+  )
+)
+
+opt <-parse_args(OptionParser(option_list = option_list))
+
+if (opt$version){
+  # print version and exit
+  cat(paste("PanCancer version", toString(packageVersion("pancancer"))), "\n")
+  quit()
+}
+
+
 # Set File Names
-base_file <- file.path("classifiers", "TP53")
+if ( !is.na(opt$alt_folder) ){
+  base_file <- opt$alt_folder
+} else {
+  base_file <- file.path("classifiers", "TP53")
+}
 burden_file <- file.path(base_file, "tables", "copy_burden_predictions.tsv")
-snaptron_file <- file.path("scripts", "snaptron",
-                           "junctions_with_mutations.csv.gz")
+if ( !is.na(opt$alt_folder) ){
+  snaptron_file <- opt$junctions_with_mutations
+} else {
+  snaptron_file <- file.path("scripts", "snaptron",
+                             "junctions_with_mutations.csv.gz")
+}
+
+
 frac_alt_plot <- file.path(base_file, "figures", "fraction_altered_plot.pdf")
 violin_plot <- file.path(base_file, "figures", "seg_altered_violin_plot.pdf")
 

--- a/scripts/copy_burden_merge.py
+++ b/scripts/copy_burden_merge.py
@@ -22,7 +22,7 @@ import pandas as pd
 parser = argparse.ArgumentParser()
 parser.add_argument('-c', '--classifier_folder',
                     help='string of the location of classifier data')
-parser.add_argument( '--filename_burden', default=None,
+parser.add_argument('--filename_burden', default=None,
                     help='Filename of burden')
 args = parser.parse_args()
 

--- a/scripts/copy_burden_merge.py
+++ b/scripts/copy_burden_merge.py
@@ -22,11 +22,13 @@ import pandas as pd
 parser = argparse.ArgumentParser()
 parser.add_argument('-c', '--classifier_folder',
                     help='string of the location of classifier data')
+parser.add_argument( '--filename_burden', default=None,
+                    help='Filename of burden')
 args = parser.parse_args()
 
 # Load command arguments
 pred_fild = os.path.join(args.classifier_folder, 'classifier_decisions.tsv')
-burden_file = os.path.join('data', 'seg_based_scores.tsv')
+burden_file = args.filename_burden or os.path.join('data', 'seg_based_scores.tsv')
 out_file = os.path.join(os.path.dirname(pred_fild), 'tables',
                         'copy_burden_predictions.tsv')
 

--- a/scripts/map_mutation_class.py
+++ b/scripts/map_mutation_class.py
@@ -33,12 +33,11 @@ parser.add_argument('-g', '--genes',
                     help='string of the genes to extract or genelist file')
 parser.add_argument('-c', '--copy_number', action='store_true',
                     help='optional flag to include copy number info in map')
-
-parser.add_argument( '--filename_copy_loss', default=None,
+parser.add_argument('--filename_copy_loss', default=None,
                     help='Filename of copy number loss')
-parser.add_argument( '--filename_copy_gain', default=None,
+parser.add_argument('--filename_copy_gain', default=None,
                     help='Filename of copy number gain')
-parser.add_argument( '--filename_raw_mut', default=None,
+parser.add_argument('--filename_raw_mut', default=None,
                     help='Filename of raw mut MAF')
 
 args = parser.parse_args()

--- a/scripts/map_mutation_class.py
+++ b/scripts/map_mutation_class.py
@@ -33,6 +33,14 @@ parser.add_argument('-g', '--genes',
                     help='string of the genes to extract or genelist file')
 parser.add_argument('-c', '--copy_number', action='store_true',
                     help='optional flag to include copy number info in map')
+
+parser.add_argument( '--filename_copy_loss', default=None,
+                    help='Filename of copy number loss')
+parser.add_argument( '--filename_copy_gain', default=None,
+                    help='Filename of copy number gain')
+parser.add_argument( '--filename_raw_mut', default=None,
+                    help='Filename of raw mut MAF')
+
 args = parser.parse_args()
 
 scores = args.scores
@@ -53,7 +61,7 @@ if not os.path.exists(out_dir):
     os.makedirs(out_dir)
 
 out_file = os.path.join(out_dir, 'mutation_classification_scores.tsv')
-raw_mut_file = os.path.join('data', 'raw', 'mc3.v0.2.8.PUBLIC.maf')
+raw_mut_file = args.filename_raw_mut or os.path.join('data', 'raw', 'mc3.v0.2.8.PUBLIC.maf')
 
 pred_df = pd.read_table(prediction_file, index_col=0)
 mut_df = pd.read_table(raw_mut_file)
@@ -71,8 +79,8 @@ map_df['Variant_Classification'] = map_df['Variant_Classification']\
                                          .fillna('Wild-Type')
 if copy_number:
     # Load Copy Number info
-    copy_loss_file = os.path.join('data', 'copy_number_loss_status.tsv')
-    copy_gain_file = os.path.join('data', 'copy_number_gain_status.tsv')
+    copy_loss_file = args.filename_copy_loss or os.path.join('data', 'copy_number_loss_status.tsv')
+    copy_gain_file = args.filename_copy_gain or os.path.join('data', 'copy_number_gain_status.tsv')
 
     copy_loss_df = pd.read_table(copy_loss_file, index_col=0)
     copy_gain_df = pd.read_table(copy_gain_file, index_col=0)

--- a/scripts/pancancer_classifier.py
+++ b/scripts/pancancer_classifier.py
@@ -71,9 +71,9 @@ sys.path.insert(0, os.path.join('scripts', 'util'))
 from tcga_util import get_args, get_threshold_metrics, integrate_copy_number
 from tcga_util import shuffle_columns
 
+# RASopathy genes as defined by https://www.ncbi.nlm.nih.gov/gtr/tests/GTR000521315/methodology/
 RASOPATHY_GENES = set(['BRAF', 'CBL', 'HRAS', 'KRAS', 'MAP2K1', 'MAP2K2', 'NF1',
                       'NRAS', 'PTPN11', 'RAF1', 'SHOC2', 'SOS1', 'SPRED1', 'RIT1'])
-
 
 # Load command arguments
 args = get_args()

--- a/scripts/pancancer_classifier.py
+++ b/scripts/pancancer_classifier.py
@@ -186,7 +186,7 @@ if drop_rasopathy:
 else:
     drop_x_genes = set()
 if args.drop_x_genes:
-    drop_x_genes = drop_x_genes.union( set( map( lambda x: x.strip(), args.drop_x_genes.split(',') ) ) )
+    drop_x_genes = drop_x_genes.union(set(args.drop_x_genes))
 if drop_x_genes:
     x_drop = list(drop_x_genes.intersection(rnaseq_full_df.columns))
     rnaseq_full_df.drop(x_drop, axis=1, inplace=True)

--- a/scripts/pancancer_classifier.py
+++ b/scripts/pancancer_classifier.py
@@ -144,8 +144,10 @@ alt_gene_summary_file = os.path.join(base_folder,
                                      '{}_summary.tsv'.format(alt_gene_base))
 
 # Load Datasets
+x_as_raw = args.x_as_raw
 if x_matrix == 'raw':
     expr_file = os.path.join('data', 'pancan_rnaseq_freeze.tsv.gz')
+    x_as_raw = True
 else:
     expr_file = x_matrix
 
@@ -160,7 +162,7 @@ mut_burden = pd.read_table(mut_burden_file)
 
 # Construct data for classifier
 common_genes = set(mutation_df.columns).intersection(genes)
-if x_matrix == 'raw':
+if x_as_raw:
     common_genes = list(common_genes.intersection(rnaseq_full_df.columns))
 else:
     common_genes = list(common_genes)
@@ -173,7 +175,7 @@ if len(common_genes) != len(genes):
                   'are {}'.format(missing_genes), category=Warning)
 
 if drop:
-    if x_matrix == 'raw':
+    if x_as_raw:
         rnaseq_full_df.drop(common_genes, axis=1, inplace=True)
 
 if drop_rasopathy:
@@ -251,7 +253,7 @@ strat = y_sub.str.cat(y_df.astype(str))
 x_df = rnaseq_df.loc[y_df.index, :]
 
 # Subset x matrix to MAD genes and scale
-if x_matrix == 'raw':
+if x_as_raw:
     med_dev = pd.DataFrame(mad(x_df), index=x_df.columns)
     mad_genes = med_dev.sort_values(by=0, ascending=False)\
                        .iloc[0:num_features_kept].index.tolist()
@@ -672,7 +674,7 @@ if alt_genes[0] is not 'None':
 
     # Process alternative x matrix
     x_alt_df = rnaseq_alt_df.loc[y_alt_df.index, :]
-    if x_matrix == 'raw':
+    if x_as_raw:
         x_alt_df = x_alt_df.loc[:, mad_genes]
 
     x_alt_df_update = pd.DataFrame(fitted_scaler.transform(x_alt_df),

--- a/scripts/pancancer_classifier.py
+++ b/scripts/pancancer_classifier.py
@@ -55,6 +55,8 @@ import warnings
 import pandas as pd
 import csv
 import argparse
+import matplotlib
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import seaborn as sns
 

--- a/scripts/snaptron/process-tp53-exons.ipynb
+++ b/scripts/snaptron/process-tp53-exons.ipynb
@@ -18,7 +18,8 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "alt_folder = os.environ.get('PANCANCER_ALT_FOLDER')\n"
    ]
   },
   {
@@ -116,7 +117,7 @@
    ],
    "source": [
     "# Load Sample File\n",
-    "sample_file = 'samples.tsv.gz'\n",
+    "sample_file = os.environ.get('PANCANCER_SNAPTRON_SAMPLES_FILE') or 'samples.tsv.gz'\n",
     "\n",
     "dictionary_df = (\n",
     "    pd.read_table(sample_file, low_memory=False)\n",
@@ -243,7 +244,7 @@
    ],
    "source": [
     "# Load junctions file\n",
-    "junction_file = 'tp53_junctions.txt.gz'\n",
+    "junction_file = os.environ.get('PANCANCER_SNAPTRON_JUNCTIONS_FILE') or 'tp53_junctions.txt.gz'\n",
     "\n",
     "junction_df = pd.read_table(junction_file)\n",
     "junction_df.head(2)"
@@ -384,8 +385,12 @@
    ],
    "source": [
     "# Load mutation classification scores file\n",
-    "file = os.path.join('..', '..', 'classifiers', 'TP53',\n",
-    "                    'tables', 'mutation_classification_scores.tsv')\n",
+    "if alt_folder:\n",
+    "    file = os.path.join(alt_folder,\n",
+    "                        'tables', 'mutation_classification_scores.tsv')\n",
+    "else:\n",
+    "    file = os.path.join('..', '..', 'classifiers', 'TP53',\n",
+    "                        'tables', 'mutation_classification_scores.tsv')\n",
     "\n",
     "mut_scores_df = pd.read_table(file, index_col=0)\n",
     "mut_scores_df.head(2)"
@@ -620,7 +625,7 @@
    ],
    "source": [
     "# Load raw mutation file\n",
-    "file = os.path.join('..', '..', 'data', 'raw', 'mc3.v0.2.8.PUBLIC.maf.gz')\n",
+    "file = os.environ.get('PANCANCER_MUT_MAF_FILE') or os.path.join('..', '..', 'data', 'raw', 'mc3.v0.2.8.PUBLIC.maf.gz')\n",
     "\n",
     "raw_mut_df = pd.read_table(file)\n",
     "raw_mut_df.head()"
@@ -784,7 +789,7 @@
    ],
    "source": [
     "# Load binary mutation file\n",
-    "file = os.path.join('..', '..', 'data', 'pancan_mutation_freeze.tsv')\n",
+    "file = os.environ.get('PANCANCER_MUT_FILE') or os.path.join('..', '..', 'data', 'pancan_mutation_freeze.tsv')\n",
     "\n",
     "mut_df = pd.read_table(file, index_col=0)\n",
     "mut_df.head(2)"
@@ -1117,7 +1122,7 @@
    ],
    "source": [
     "# Process and output junction file\n",
-    "out_file = 'tp53_junctions_with_mutations.csv.gz'\n",
+    "out_file = os.environ.get('PANCANCER_JUNCTIONS_MUTIONS_OUTPUT_FILE') or 'tp53_junctions_with_mutations.csv.gz'\n",
     "\n",
     "junctions_process_df = (\n",
     "    junction_df.assign(diff_start = abs(7675994 - junction_df['start']),\n",
@@ -1154,7 +1159,12 @@
     "    .merge(mut_scores_df, left_on='tcga_id', right_index=True)\n",
     ")\n",
     "\n",
-    "junctions_process_df.to_csv(out_file, compression='gzip')\n",
+    "# FIXME, compression to infer, on pandas update 0.24.0+\n",
+    "if out_file.endswith('.gz'):\n",
+    "    compression_type = 'gzip'\n",
+    "else:\n",
+    "    compression_type = None\n",
+    "junctions_process_df.to_csv(out_file, compression=compression_type)\n",
     "junctions_process_df.head(2)"
    ]
   }

--- a/scripts/snaptron/process_tp53_junctions.py
+++ b/scripts/snaptron/process_tp53_junctions.py
@@ -38,15 +38,16 @@ def get_rail_id(row):
             all_sample_ids.append(sample_id)
     return(all_sample_ids)
 
+
 parser = argparse.ArgumentParser()
 
 parser.add_argument('--sample_file', default=None,
                     help='Filename of SNAPTRON samples')
-parser.add_argument( '--junction_file', default=None,
+parser.add_argument('--junction_file', default=None,
                     help='Filename of SNAPTRON junctions')
-parser.add_argument( '--alt_folder', default=None,
+parser.add_argument('--alt_folder', default=None,
                     help='Folder containing classifier')
-parser.add_argument( '--output', default=None,
+parser.add_argument('--output', default=None,
                     help='Filename of output junctions')
 
 args = parser.parse_args()

--- a/scripts/tp53_ddr_cancertype_subtypes.ipynb
+++ b/scripts/tp53_ddr_cancertype_subtypes.ipynb
@@ -31,7 +31,8 @@
     "import os\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns"
+    "import seaborn as sns\n",
+    "alt_folder = os.environ.get('PANCANCER_ALT_FOLDER')\n"
    ]
   },
   {
@@ -200,8 +201,12 @@
    ],
    "source": [
     "# The prediction file stores the TP53 classifier scores for all samples\n",
-    "prediction_file = os.path.join('..', 'classifiers', 'TP53', 'tables',\n",
-    "                               'mutation_classification_scores.tsv')\n",
+    "if alt_folder:\n",
+    "    prediction_file = os.path.join(alt_folder, 'tables',\n",
+    "                                   'mutation_classification_scores.tsv')\n",
+    "else:\n",
+    "    prediction_file = os.path.join('..', 'classifiers', 'TP53', 'tables',\n",
+    "                                   'mutation_classification_scores.tsv')\n",
     "prediction_df = pd.read_table(prediction_file, index_col=0)\n",
     "prediction_df.head(2)"
    ]
@@ -254,7 +259,8 @@
     }
    ],
    "source": [
-    "figure_name = os.path.join('..', 'figures', 'TP53_opposite_spectrum_cancertypes.pdf')\n",
+    "figure_name = alt_folder or '..'\n",
+    "figure_name = os.path.join(figure_name, 'figures', 'TP53_opposite_spectrum_cancertypes.pdf')\n",
     "plt.figure(figsize=(2, 6))\n",
     "g = sns.factorplot(x='total_status', y='weight', col='DISEASE', data=extreme_df,\n",
     "                   palette=\"hls\", col_order=extreme_types, kind='strip', jitter=0.4,\n",
@@ -323,7 +329,8 @@
     }
    ],
    "source": [
-    "brca_file_name = os.path.join('..', 'figures', 'TP53_BRCA_subtype_confounding.pdf')\n",
+    "brca_file_name = alt_folder or '..'\n",
+    "brca_file_name = os.path.join(brca_file_name, 'figures', 'TP53_BRCA_subtype_confounding.pdf')\n",
     "plot_subtype(brca_df, 'BRCA')\n",
     "plt.savefig(brca_file_name, dpi=600, bbox_inchex='tight')"
    ]
@@ -345,7 +352,8 @@
     }
    ],
    "source": [
-    "ucec_file_name = os.path.join('..', 'figures', 'TP53_UCEC_subtype_confounding.pdf')\n",
+    "ucec_file_name = alt_folder or '..'\n",
+    "ucec_file_name = os.path.join(ucec_file_name, 'figures', 'TP53_UCEC_subtype_confounding.pdf')\n",
     "plot_subtype(ucec_df, 'UCEC')\n",
     "plt.savefig(ucec_file_name, dpi=600, bbox_inchex='tight')"
    ]

--- a/scripts/tp53_phenocopy.ipynb
+++ b/scripts/tp53_phenocopy.ipynb
@@ -24,7 +24,8 @@
     "from scipy.stats import ttest_ind\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns"
+    "import seaborn as sns\n",
+    "alt_folder = os.environ.get('PANCANCER_ALT_FOLDER')\n"
    ]
   },
   {
@@ -98,9 +99,9 @@
    "outputs": [],
    "source": [
     "# Load mutation, copy number, and sample freeze data\n",
-    "mut_file = os.path.join('..', 'data', 'pancan_mutation_freeze.tsv')\n",
-    "gistic_file = os.path.join('..', 'data', 'raw', 'pancan_GISTIC_threshold.tsv')\n",
-    "sample_freeze_file = os.path.join('..', 'data', 'sample_freeze.tsv')\n",
+    "mut_file = os.environ.get('PANCANCER_MUT_FILE') or os.path.join('..', 'data', 'pancan_mutation_freeze.tsv')\n",
+    "gistic_file = os.environ.get('PANCANCER_GISTIC_FILE') or os.path.join('..', 'data', 'raw', 'pancan_GISTIC_threshold.tsv')\n",
+    "sample_freeze_file = os.environ.get('PANCANCER_SAMPLE_FREEZE_FILE') or os.path.join('..', 'data', 'sample_freeze.tsv')\n",
     "\n",
     "mutation_df = pd.read_table(mut_file, index_col=0)\n",
     "copy_df = pd.read_table(gistic_file, index_col=0)\n",
@@ -242,8 +243,12 @@
    ],
    "source": [
     "# The prediction file stores the TP53 classifier scores for all samples\n",
-    "prediction_file = os.path.join('..', 'classifiers', 'TP53', 'tables',\n",
-    "                               'mutation_classification_scores.tsv')\n",
+    "if alt_folder:\n",
+    "    prediction_file = os.path.join(alt_folder, 'tables',\n",
+    "                                   'mutation_classification_scores.tsv')\n",
+    "else:\n",
+    "    prediction_file = os.path.join('..', 'classifiers', 'TP53', 'tables',\n",
+    "                                   'mutation_classification_scores.tsv')\n",
     "prediction_df = pd.read_table(prediction_file, index_col=0)\n",
     "prediction_df.head(2)"
    ]
@@ -803,8 +808,12 @@
     "            plt.text(y_text_amp - 0.1, y_amp + h_mut + 0.1,\n",
     "                     add_text_del, ha='center', va='bottom', color=\"black\")\n",
     "    \n",
-    "    phenocopy_fig_file = os.path.join('..', 'classifiers', 'TP53', 'figures',\n",
-    "                                      '{}_gene_phenocopy.pdf'.format(gene))\n",
+    "    if alt_folder:\n",
+    "        phenocopy_fig_file = os.path.join(alt_folder, 'figures',\n",
+    "                                          '{}_gene_phenocopy.pdf'.format(gene))\n",
+    "    else:\n",
+    "        phenocopy_fig_file = os.path.join('..', 'classifiers', 'TP53', 'figures',\n",
+    "                                          '{}_gene_phenocopy.pdf'.format(gene))\n",
     "    plt.savefig(phenocopy_fig_file, bbox_extra_artists=(l,), bbox_inches='tight')\n",
     "    plt.close()"
    ]
@@ -817,7 +826,11 @@
    "source": [
     "output_df = pd.DataFrame(output_results, columns=['gene', 'gene_b', 'event',\n",
     "                                                  'neg_logp', 'p', 'effect_size'])\n",
-    "output_file = os.path.join('..', 'results', 'tp53_phenocopy_results.tsv')\n",
+    "output_file = alt_folder or '..'\n",
+    "output_file = os.path.join(output_file, 'results')\n",
+    "if not os.path.exists(output_file):\n",
+    "    os.makedirs(output_file)\n",
+    "output_file = os.path.join(output_file, 'tp53_phenocopy_results.tsv')\n",
     "output_df.sort_values(by='gene').to_csv(output_file, sep='\\t', index=False)"
    ]
   }

--- a/scripts/util/pancancer_util.R
+++ b/scripts/util/pancancer_util.R
@@ -51,7 +51,9 @@ parse_summary <- function(summary_info) {
   # Output:
   #    a list of summarized classifier attributes and performance
 
+  base_dir <- NULL
   if (is.character(summary_info)) {
+    base_dir <- dirname(summary_info)
     summary_info <- readr::read_lines(summary_info)
   }
   summary_list <- list()
@@ -72,8 +74,12 @@ parse_summary <- function(summary_info) {
       next
     }
     if (line[1] == "Coefficients:") {
+      tmp_fn <- line[2]
+      if ( ! file.exists(tmp_fn)){
+        tmp_fn <- file.path( base_dir, 'classifier_coefficients.tsv' ) # maybe should use basename of not found file
+      }
       summary_list[[sub(":", "", line[1])]] <-
-        suppressMessages(readr::read_tsv(line[2]))
+        suppressMessages(readr::read_tsv(tmp_fn))
     } else if (line[1] == "") {
       disease_info <- line[2:length(line)]
       disease <- disease_info[1]

--- a/scripts/util/tcga_util.py
+++ b/scripts/util/tcga_util.py
@@ -63,8 +63,8 @@ def get_args():
                         help='Remove mutation data from y matrix')
     parser.add_argument('-z', '--drop_rasopathy', action='store_true',
                         help='Decision to drop rasopathy genes from X matrix')
-    parser.add_argument('--drop_x_genes', default=None,
-                        help='Comma separated list of genes to be dropped from X matrix')
+    parser.add_argument('--drop_x_genes', default=None, nargs='+',
+                        help='Genes to be dropped from X matrix')
     parser.add_argument('-q', '--drop_expression', action='store_true',
                         help='Decision to drop gene expression values from X')
     parser.add_argument('-j', '--drop_covariates', action='store_true',

--- a/scripts/util/tcga_util.py
+++ b/scripts/util/tcga_util.py
@@ -12,7 +12,7 @@ def get_args():
     Get arguments for the main pancancer classifier script
     """
     import argparse
-    
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-g', '--genes',
                         help='Comma separated string of HUGO gene symbols')
@@ -63,23 +63,23 @@ def get_args():
                         help='Remove mutation data from y matrix')
     parser.add_argument('-z', '--drop_rasopathy', action='store_true',
                         help='Decision to drop rasopathy genes from X matrix')
-    parser.add_argument( '--drop_x_genes', default=None,
+    parser.add_argument('--drop_x_genes', default=None,
                         help='Comma separated list of genes to be dropped from X matrix')
     parser.add_argument('-q', '--drop_expression', action='store_true',
                         help='Decision to drop gene expression values from X')
     parser.add_argument('-j', '--drop_covariates', action='store_true',
                         help='Decision to drop covariate information from X')
-    parser.add_argument( '--filename_mut', default=None,
+    parser.add_argument('--filename_mut', default=None,
                         help='Filename of sample/gene mutations to use in model')
-    parser.add_argument( '--filename_mut_burden', default=None,
+    parser.add_argument('--filename_mut_burden', default=None,
                         help='Filename of sample mutation burden to use in model')
-    parser.add_argument( '--filename_sample', default=None,
+    parser.add_argument('--filename_sample', default=None,
                         help='Filename of patient/samples to use in model')
-    parser.add_argument( '--filename_copy_loss', default=None,
+    parser.add_argument('--filename_copy_loss', default=None,
                         help='Filename of copy number loss')
-    parser.add_argument( '--filename_copy_gain', default=None,
+    parser.add_argument('--filename_copy_gain', default=None,
                         help='Filename of copy number gain')
-    parser.add_argument( '--filename_cancer_gene_classification', default=None,
+    parser.add_argument('--filename_cancer_gene_classification', default=None,
                         help='Filename of cancer gene classification table')
 
     args = parser.parse_args()

--- a/scripts/util/tcga_util.py
+++ b/scripts/util/tcga_util.py
@@ -61,10 +61,24 @@ def get_args():
                         help='Remove mutation data from y matrix')
     parser.add_argument('-z', '--drop_rasopathy', action='store_true',
                         help='Decision to drop rasopathy genes from X matrix')
+    parser.add_argument( '--drop_x_genes', default=None,
+                        help='Comma separated list of genes to be dropped from X matrix')
     parser.add_argument('-q', '--drop_expression', action='store_true',
                         help='Decision to drop gene expression values from X')
     parser.add_argument('-j', '--drop_covariates', action='store_true',
                         help='Decision to drop covariate information from X')
+    parser.add_argument( '--filename_mut', default=None,
+                        help='Filename of sample/gene mutations to use in model')
+    parser.add_argument( '--filename_mut_burden', default=None,
+                        help='Filename of sample mutation burden to use in model')
+    parser.add_argument( '--filename_sample', default=None,
+                        help='Filename of patient/samples to use in model')
+    parser.add_argument( '--filename_copy_loss', default=None,
+                        help='Filename of copy number loss')
+    parser.add_argument( '--filename_copy_gain', default=None,
+                        help='Filename of copy number gain')
+    parser.add_argument( '--filename_cancer_gene_classification', default=None,
+                        help='Filename of cancer gene classification table')
 
     args = parser.parse_args()
     return args

--- a/scripts/util/tcga_util.py
+++ b/scripts/util/tcga_util.py
@@ -53,6 +53,8 @@ def get_args():
                         help='Keep intermediate ROC values for plotting')
     parser.add_argument('-x', '--x_matrix', default='raw',
                         help='Filename of features to use in model')
+    parser.add_argument('--x_as_raw', action='store_true',
+                        help='Treat x_matrix as "raw"')
     parser.add_argument('-e', '--shuffled', action='store_true',
                         help='Shuffle the input gene exprs matrix alongside')
     parser.add_argument('--shuffled_before_training', action='store_true',

--- a/scripts/visualize_decisions.py
+++ b/scripts/visualize_decisions.py
@@ -16,6 +16,8 @@ Output:
 import os
 import argparse
 import pandas as pd
+import matplotlib
+matplotlib.use('agg')
 import seaborn as sns
 import matplotlib.pyplot as plt
 

--- a/scripts/viz/ddr_summary_figures.R
+++ b/scripts/viz/ddr_summary_figures.R
@@ -15,9 +15,41 @@
 library(dplyr)
 library(pheatmap)
 library(ggplot2)
+library(optparse)
 source(file.path("scripts", "util", "pancancer_util.R"))
 
-results_folder <- file.path("classifiers", "TP53")
+# parse options
+option_list = list(
+   make_option(
+    c("--version"),
+    action = "store_true",
+    default = FALSE,
+    help = "Print version and exit"
+   ),
+  make_option(
+    c("--alt_folder"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = "Input Classifier folder"
+  )
+)
+
+opt <-parse_args(OptionParser(option_list = option_list))
+
+if (opt$version){
+  # print version and exit
+  cat(paste("PanCancer version", toString(packageVersion("pancancer"))), "\n")
+  quit()
+}
+
+# Check parameter values
+if ( !is.na(opt$alt_folder) ){
+  results_folder <- opt$alt_folder
+} else {
+  results_folder <- file.path("classifiers", "TP53")
+}
+
 results <- parse_summary(file.path(results_folder, "classifier_summary.txt"))
 
 # 1) Heatmap of the distribution of aberrant events across tumors

--- a/scripts/within_tissue_analysis.py
+++ b/scripts/within_tissue_analysis.py
@@ -40,7 +40,6 @@ parser.add_argument('-v', '--remove_hyper', action='store_true',
                     help='Remove hypermutated samples')
 parser.add_argument('-f', '--alt_folder', default='Auto',
                     help='location to save')
-
 parser.add_argument('-x', '--x_matrix', default=None,
                     help='Filename of features to use in model')
 parser.add_argument('--filename_mut', default=None,

--- a/scripts/within_tissue_analysis.py
+++ b/scripts/within_tissue_analysis.py
@@ -43,17 +43,17 @@ parser.add_argument('-f', '--alt_folder', default='Auto',
 
 parser.add_argument('-x', '--x_matrix', default=None,
                     help='Filename of features to use in model')
-parser.add_argument( '--filename_mut', default=None,
+parser.add_argument('--filename_mut', default=None,
                     help='Filename of sample/gene mutations to use in model')
-parser.add_argument( '--filename_mut_burden', default=None,
+parser.add_argument('--filename_mut_burden', default=None,
                     help='Filename of sample mutation burden to use in model')
-parser.add_argument( '--filename_sample', default=None,
+parser.add_argument('--filename_sample', default=None,
                     help='Filename of patient/samples to use in model')
-parser.add_argument( '--filename_copy_loss', default=None,
+parser.add_argument('--filename_copy_loss', default=None,
                     help='Filename of copy number loss')
-parser.add_argument( '--filename_copy_gain', default=None,
+parser.add_argument('--filename_copy_gain', default=None,
                     help='Filename of copy number gain')
-parser.add_argument( '--filename_cancer_gene_classification', default=None,
+parser.add_argument('--filename_cancer_gene_classification', default=None,
                     help='Filename of cancer gene classification table')
 
 
@@ -61,7 +61,7 @@ args = parser.parse_args()
 
 # make it a little easier to pass forward filename args
 args_dict = vars(args)
-filename_arg_list = [ 'x_matrix' ]
+filename_arg_list = ['x_matrix']
 for k in args_dict.keys():
     if k.startswith('filename_'):
         filename_arg_list.append(k)

--- a/scripts/within_tissue_analysis.py
+++ b/scripts/within_tissue_analysis.py
@@ -41,7 +41,30 @@ parser.add_argument('-v', '--remove_hyper', action='store_true',
 parser.add_argument('-f', '--alt_folder', default='Auto',
                     help='location to save')
 
+parser.add_argument('-x', '--x_matrix', default=None,
+                    help='Filename of features to use in model')
+parser.add_argument( '--filename_mut', default=None,
+                    help='Filename of sample/gene mutations to use in model')
+parser.add_argument( '--filename_mut_burden', default=None,
+                    help='Filename of sample mutation burden to use in model')
+parser.add_argument( '--filename_sample', default=None,
+                    help='Filename of patient/samples to use in model')
+parser.add_argument( '--filename_copy_loss', default=None,
+                    help='Filename of copy number loss')
+parser.add_argument( '--filename_copy_gain', default=None,
+                    help='Filename of copy number gain')
+parser.add_argument( '--filename_cancer_gene_classification', default=None,
+                    help='Filename of cancer gene classification table')
+
+
 args = parser.parse_args()
+
+# make it a little easier to pass forward filename args
+args_dict = vars(args)
+filename_arg_list = [ 'x_matrix' ]
+for k in args_dict.keys():
+    if k.startswith('filename_'):
+        filename_arg_list.append(k)
 
 # Load command arguments
 genes = args.genes
@@ -74,4 +97,9 @@ for acronym in disease_types:
                '--alt_folder', alt_folder, '--shuffled', '--keep_intermediate']
     if remove_hyper:
         command += ['--remove_hyper']
+    # Only set filename if it has been set
+    for fname_arg in filename_arg_list:
+        val = args_dict.get(fname_arg, None)
+        if val:
+            command += ['--%s' % (fname_arg), val]
     subprocess.call(command)


### PR DESCRIPTION
The primary goal of this PR is to allow control of input and output paths and to e.g. enable execution on a file staging cluster setup. 

All changes should be 100% backwards compatible, but I did not find a test suite that I could run to doubly confirm. 

Also addresses some quirks when e.g. running on a file staging cluster, where files are created in temporary directories (so full path to `classifier_coefficients.tsv` declared in files may no longer exist). If the file DNE, it looks for a copy local to the current classifier folder structure.

I added an argument `--x_as_raw` to pancancer_classifier.py to handle the special casing that was keyed based upon using default value for `--x_matrix`; which is `raw` and causes `pancan_rnaseq_freeze.tsv.gz` to be used. if you had specified `pancan_rnaseq_freeze.tsv.gz` directly as input, then the 'raw' actions were never performed; now you can do both. Probably a better, more descriptive, terminology than `raw` could be proposed.

Add `--drop_x_genes` to pancancer_classifier.py to enable custom list of genes to be dropped, similar to rasopathy_genes. Also explicitly set `matplotlib.use('agg')` to work on headless systems.

An upgrade to pandas 0.24.0+ will give 'infer' option for compression in `to_csv()` which is now currently being worked around for gzip outputs. Pandas currently pinned at 0.23.0 in `environment.yml`.

In cases of jupyter notebooks that are run as scripts, I parameterize the execution with environmental variables.
